### PR TITLE
Clear EXIT messages from readfuns processes

### DIFF
--- a/src/gen_flow.erl
+++ b/src/gen_flow.erl
@@ -107,6 +107,9 @@ loop(Parent, Debug, #state{pids=Pids0,
     %% Terminate pids that might still be running.
     terminate(Pids0),
 
+    %% Clear EXIT messages from previous pids
+    clear_exit_inbox(Parent),
+
     %% Get self.
     Self = self(),
 
@@ -189,6 +192,7 @@ loop(Parent, Debug, #state{pids=Pids0,
 
         {'EXIT', Parent, Reason} ->
             exit(Reason)
+
     after
         60000 ->
             %% If 60 seconds go by, relaunch.
@@ -220,6 +224,15 @@ system_replace_state(StateFun, State) ->
 clear_inbox() ->
     receive
         _ -> clear_inbox()
+    after
+        0 -> ok
+    end.
+
+%% @private
+clear_exit_inbox(Parent) ->
+    receive
+        {'EXIT', Parent, Reason} -> exit(Reason);
+        {'EXIT', _, _} -> clear_exit_inbox(Parent)
     after
         0 -> ok
     end.


### PR DESCRIPTION
I've noticed that over time `gen_flow` process gets an huge messages inbox: the `EXIT` messages from the spawned readfuns linked processes don't get cleaned up, so they keep accumulating, and uses a lot of memory and wastes some processing when doing pattern matching from the inbox.

I've chosen to recursively clean the inbox from `EXIT` messages at each beginning of a loop, to not interfere with it.